### PR TITLE
modify redis manager layout

### DIFF
--- a/resources/views/layout.blade.php
+++ b/resources/views/layout.blade.php
@@ -13,11 +13,13 @@
             <div class="box-body no-padding">
                 <ul class="nav nav-pills nav-stacked">
                     @foreach($connections as $name => $connection)
+						@if(!empty($connection['host']))
                         <li @if($name == $conn)class="active"@endif>
                             <a href=" {{ route('redis-index', ['conn' => $name]) }}">
                                 <i class="fa fa-database"></i> {{ $name }}  &nbsp;&nbsp;<small>[{{ $connection['host'].':'.$connection['port'] }}]</small>
                             </a>
                         </li>
+						@endif
                     @endforeach
                 </ul>
             </div>


### PR DESCRIPTION
Laravel Framework 5.8.4  会报错 
database.php  options 参数下没有相关配置 

    'redis' => [

        'client' => env('REDIS_CLIENT', 'predis'),

        'options' => [
            'cluster' => env('REDIS_CLUSTER', 'predis'),
        ],

        'default' => [
            'host' => env('REDIS_HOST', '127.0.0.1'),
            'password' => env('REDIS_PASSWORD', null),
            'port' => env('REDIS_PORT', 6379),
            'database' => env('REDIS_DB', 0),
        ],

        'cache' => [
            'host' => env('REDIS_HOST', '127.0.0.1'),
            'password' => env('REDIS_PASSWORD', null),
            'port' => env('REDIS_PORT', 6379),
            'database' => env('REDIS_CACHE_DB', 1),
        ],
