### PR TITLE
修改连接方式设置为phpredis拓展产生报错的问题

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,14 +1,14 @@
 {
-    "name": "laravel-admin-ext/redis-manager",
-    "description": "Redis manager for laravel-admin",
+    "name": "pennfly/redis-manager",
+    "description": "Redis manager for laravel-admin ， and do my self",
     "type": "library",
     "keywords": ["laravel-admin", "redis", "manager"],
-    "homepage": "https://github.com/laravel-admin-extensions/redis-manager",
+    "homepage": "https://github.com/pennfly/redis-manager",
     "license": "MIT",
     "authors": [
         {
-            "name": "z-song",
-            "email": "zosong@126.com"
+            "name": "pennfly",
+            "email": "pennilessfor@gmail.com"
         }
     ],
     "require": {

--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,8 @@
 {
     "name": "pennfly/redis-manager",
-    "description": "Redis manager for laravel-admin ， and do my self",
+    "description": "Redis manager for laravel-admin . This is a fork project, because I want fix chagne config phpredis had err.",
     "type": "library",
-    "keywords": ["laravel-admin", "redis", "manager"],
+    "keywords": ["laravel-admin", "redis", "manager", "phpredis"],
     "homepage": "https://github.com/pennfly/redis-manager",
     "license": "MIT",
     "authors": [

--- a/src/RedisManager.php
+++ b/src/RedisManager.php
@@ -146,7 +146,7 @@ class RedisManager extends Extension
         if ($connection) {
             $this->connection = $connection;
         }
-
+        Redis::setDriver('predis');
         return Redis::connection($this->connection);
     }
 


### PR DESCRIPTION
**问题描述**
`config/database.php` 中redis设置` 'client' => env('REDIS_CLIENT', 'phpredis'),` 拓展会产生报错

**报错信息**
`Argument 1 passed to Predis\Collection\Iterator\Keyspace::__construct() must be an instance of Predis\ClientInterface, instance of Redis given, called in vendor/laravel-admin-ext/redis-manager/src/RedisManager.php on line 176`

**解决方案**
`Redis::setDriver('predis');` 在拓展中强制使用predis连接数据库。