### PR TITLE
replace deprecated functions

### DIFF
--- a/src/DataType/Hashes.php
+++ b/src/DataType/Hashes.php
@@ -2,6 +2,8 @@
 
 namespace Encore\Admin\RedisManager\DataType;
 
+use Illuminate\Support\Arr;
+
 class Hashes extends DataType
 {
     /**
@@ -17,18 +19,18 @@ class Hashes extends DataType
      */
     public function update(array $params)
     {
-        $key = array_get($params, 'key');
+        $key = Arr::get($params, 'key');
 
-        if (array_has($params, 'field')) {
-            $field = array_get($params, 'field');
-            $value = array_get($params, 'value');
+        if (Arr::has($params, 'field')) {
+            $field = Arr::get($params, 'field');
+            $value = Arr::get($params, 'value');
 
             $this->getConnection()->hset($key, $field, $value);
         }
 
-        if (array_has($params, '_editable')) {
-            $value = array_get($params, 'value');
-            $field = array_get($params, 'pk');
+        if (Arr::has($params, '_editable')) {
+            $value = Arr::get($params, 'value');
+            $field = Arr::get($params, 'pk');
 
             $this->getConnection()->hset($key, $field, $value);
         }
@@ -39,10 +41,10 @@ class Hashes extends DataType
      */
     public function store(array $params)
     {
-        $key = array_get($params, 'key');
-        $ttl = array_get($params, 'ttl');
-        $field = array_get($params, 'field');
-        $value = array_get($params, 'value');
+        $key = Arr::get($params, 'key');
+        $ttl = Arr::get($params, 'ttl');
+        $field = Arr::get($params, 'field');
+        $value = Arr::get($params, 'value');
 
         $this->getConnection()->hset($key, $field, $value);
 
@@ -65,8 +67,8 @@ class Hashes extends DataType
      */
     public function remove(array $params)
     {
-        $key = array_get($params, 'key');
-        $field = array_get($params, 'field');
+        $key = Arr::get($params, 'key');
+        $field = Arr::get($params, 'field');
 
         return $this->getConnection()->hdel($key, [$field]);
     }

--- a/src/DataType/Lists.php
+++ b/src/DataType/Lists.php
@@ -2,6 +2,8 @@
 
 namespace Encore\Admin\RedisManager\DataType;
 
+use Illuminate\Support\Arr;
+
 class Lists extends DataType
 {
     /**
@@ -17,18 +19,18 @@ class Lists extends DataType
      */
     public function update(array $params)
     {
-        $key = array_get($params, 'key');
+        $key = Arr::get($params, 'key');
 
-        if (array_has($params, 'push')) {
-            $item = array_get($params, 'item');
+        if (Arr::has($params, 'push')) {
+            $item = Arr::get($params, 'item');
             $command = $params['push'] == 'left' ? 'lpush' : 'rpush';
 
             $this->getConnection()->{$command}($key, $item);
         }
 
-        if (array_has($params, '_editable')) {
-            $value = array_get($params, 'value');
-            $index = array_get($params, 'pk');
+        if (Arr::has($params, '_editable')) {
+            $value = Arr::get($params, 'value');
+            $index = Arr::get($params, 'pk');
 
             $this->getConnection()->lset($key, $index, $value);
         }
@@ -39,9 +41,9 @@ class Lists extends DataType
      */
     public function store(array $params)
     {
-        $key = array_get($params, 'key');
-        $item = array_get($params, 'item');
-        $ttl = array_get($params, 'ttl');
+        $key = Arr::get($params, 'key');
+        $item = Arr::get($params, 'item');
+        $ttl = Arr::get($params, 'ttl');
 
         $this->getConnection()->rpush($key, [$item]);
 
@@ -64,8 +66,8 @@ class Lists extends DataType
      */
     public function remove(array $params)
     {
-        $key = array_get($params, 'key');
-        $index = array_get($params, 'index');
+        $key = Arr::get($params, 'key');
+        $index = Arr::get($params, 'index');
 
         $lua = <<<'LUA'
 redis.call('lset', KEYS[1], ARGV[1], '__DELETED__');

--- a/src/DataType/Sets.php
+++ b/src/DataType/Sets.php
@@ -2,6 +2,8 @@
 
 namespace Encore\Admin\RedisManager\DataType;
 
+use Illuminate\Support\Arr;
+
 class Sets extends DataType
 {
     /**
@@ -17,16 +19,16 @@ class Sets extends DataType
      */
     public function update(array $params)
     {
-        $key = array_get($params, 'key');
+        $key = Arr::get($params, 'key');
 
-        if (array_has($params, 'member')) {
-            $member = array_get($params, 'member');
+        if (Arr::has($params, 'member')) {
+            $member = Arr::get($params, 'member');
             $this->getConnection()->sadd($key, $member);
         }
 
-        if (array_has($params, '_editable')) {
-            $new = array_get($params, 'value');
-            $old = array_get($params, 'pk');
+        if (Arr::has($params, '_editable')) {
+            $new = Arr::get($params, 'value');
+            $old = Arr::get($params, 'pk');
 
             $this->getConnection()->transaction(function ($tx) use ($key, $old, $new) {
                 $tx->srem($key, $old);
@@ -40,9 +42,9 @@ class Sets extends DataType
      */
     public function store(array $params)
     {
-        $key = array_get($params, 'key');
-        $ttl = array_get($params, 'ttl');
-        $members = array_get($params, 'members');
+        $key = Arr::get($params, 'key');
+        $ttl = Arr::get($params, 'ttl');
+        $members = Arr::get($params, 'members');
 
         $this->getConnection()->sadd($key, $members);
 
@@ -65,8 +67,8 @@ class Sets extends DataType
      */
     public function remove(array $params)
     {
-        $key = array_get($params, 'key');
-        $member = array_get($params, 'member');
+        $key = Arr::get($params, 'key');
+        $member = Arr::get($params, 'member');
 
         return $this->getConnection()->srem($key, $member);
     }

--- a/src/DataType/SortedSets.php
+++ b/src/DataType/SortedSets.php
@@ -2,6 +2,8 @@
 
 namespace Encore\Admin\RedisManager\DataType;
 
+use Illuminate\Support\Arr;
+
 class SortedSets extends DataType
 {
     /**
@@ -14,17 +16,17 @@ class SortedSets extends DataType
 
     public function update(array $params)
     {
-        $key = array_get($params, 'key');
+        $key = Arr::get($params, 'key');
 
-        if (array_has($params, 'member')) {
-            $member = array_get($params, 'member');
-            $score = array_get($params, 'score');
+        if (Arr::has($params, 'member')) {
+            $member = Arr::get($params, 'member');
+            $score = Arr::get($params, 'score');
             $this->getConnection()->zadd($key, [$member => $score]);
         }
 
-        if (array_has($params, '_editable')) {
-            $score = array_get($params, 'value');
-            $member = array_get($params, 'pk');
+        if (Arr::has($params, '_editable')) {
+            $score = Arr::get($params, 'value');
+            $member = Arr::get($params, 'pk');
 
             $this->getConnection()->zadd($key, [$member => $score]);
         }
@@ -35,10 +37,10 @@ class SortedSets extends DataType
      */
     public function store(array $params)
     {
-        $key = array_get($params, 'key');
-        $ttl = array_get($params, 'ttl');
-        $score = array_get($params, 'score');
-        $member = array_get($params, 'member');
+        $key = Arr::get($params, 'key');
+        $ttl = Arr::get($params, 'ttl');
+        $score = Arr::get($params, 'score');
+        $member = Arr::get($params, 'member');
 
         $this->getConnection()->zadd($key, [$member => $score]);
 
@@ -61,8 +63,8 @@ class SortedSets extends DataType
      */
     public function remove(array $params)
     {
-        $key = array_get($params, 'key');
-        $member = array_get($params, 'member');
+        $key = Arr::get($params, 'key');
+        $member = Arr::get($params, 'member');
 
         return $this->getConnection()->zrem($key, $member);
     }

--- a/src/DataType/Strings.php
+++ b/src/DataType/Strings.php
@@ -2,6 +2,8 @@
 
 namespace Encore\Admin\RedisManager\DataType;
 
+use Illuminate\Support\Arr;
+
 class Strings extends DataType
 {
     /**
@@ -25,9 +27,9 @@ class Strings extends DataType
      */
     public function store(array $params)
     {
-        $key = array_get($params, 'key');
-        $value = array_get($params, 'value');
-        $ttl = array_get($params, 'ttl');
+        $key = Arr::get($params, 'key');
+        $value = Arr::get($params, 'value');
+        $ttl = Arr::get($params, 'ttl');
 
         $this->getConnection()->set($key, $value);
 


### PR DESCRIPTION
functions array_get() and array_has() have been deprecated since Laravel 6.0,
so replace them with Illuminate\Support\Arr::get() and Illuminate\Support\Arr::has(),
both the two new functions were found in Laravel 5.*